### PR TITLE
Add swipe animation to flashcards

### DIFF
--- a/src/styles/FlashcardStudy.css
+++ b/src/styles/FlashcardStudy.css
@@ -118,7 +118,8 @@
   cursor: pointer;
   position: relative;
   transform-style: preserve-3d;
-  transition: transform 0.6s cubic-bezier(0.4, 0.0, 0.2, 1);
+  user-select: none;
+  transition: transform 0.6s cubic-bezier(0.4, 0.0, 0.2, 1), opacity 0.3s ease;
 }
 
 .flashcard.flipped {


### PR DESCRIPTION
## Summary
- enhance flashcard study with animated swipe gestures
- adjust flashcard styles for translation and fading

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859b2520e688325afc23c549079b97c