### PR TITLE
Improve SmartQuiz mobile layout

### DIFF
--- a/src/pages/SmartQuiz.jsx
+++ b/src/pages/SmartQuiz.jsx
@@ -58,6 +58,9 @@ export default function SmartQuiz() {
   const [selectedVocabularyItem, setSelectedVocabularyItem] = useState(null);
   const [savingVocabularyItem, setSavingVocabularyItem] = useState(false);
   const [savedVocabularyItems, setSavedVocabularyItems] = useState([]);
+
+  // Mobile state for vocabulary panel visibility
+  const [mobileVocabOpen, setMobileVocabOpen] = useState(false);
   
   // Load quiz document
   useEffect(() => {
@@ -763,6 +766,82 @@ export default function SmartQuiz() {
                 <span>Level: {quiz.level} ({DIFFICULTY_FOR_LEVEL[quiz.level] || 'Unknown'})</span>
               </div>
             </div>
+
+            {aiEnabled && (
+              <>
+                <div className="mobile-ai-bar">
+                  <button
+                    className="ai-bar-button"
+                    onClick={() => setIsAssistantModalOpen(true)}
+                  >
+                    <FontAwesomeIcon icon={faComment} />
+                  </button>
+                  <button
+                    className="ai-bar-button"
+                    onClick={handleDirectTipRequest}
+                    disabled={assistantLoading}
+                  >
+                    <FontAwesomeIcon icon={faLightbulb} />
+                  </button>
+                  <button
+                    className="ai-bar-button"
+                    onClick={handleDirectSummariseText}
+                    disabled={assistantLoading}
+                  >
+                    <FontAwesomeIcon icon={faFileAlt} />
+                  </button>
+                  <button
+                    className="ai-bar-button"
+                    onClick={() => setMobileVocabOpen(!mobileVocabOpen)}
+                  >
+                    <FontAwesomeIcon icon={faBook} />
+                  </button>
+                </div>
+
+                <div className={`mobile-vocabulary-panel ${mobileVocabOpen ? 'open' : ''}`}>
+                  {helperLoading ? (
+                    <div style={{ textAlign: 'center', padding: '10px 0' }}>
+                      <p>Loading...</p>
+                    </div>
+                  ) : helperItems.length === 0 ? (
+                    <div style={{ textAlign: 'center', padding: '10px 0' }}>
+                      <p>No terms found.</p>
+                    </div>
+                  ) : (
+                    <div className="vocabulary-items" style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+                      {helperItems.map((item, index) => (
+                        <div
+                          key={index}
+                          className="vocabulary-item"
+                          onClick={() => handleVocabularyItemClick(item)}
+                          style={{
+                            padding: '8px 12px',
+                            backgroundColor: savedVocabularyItems.includes(item.term) ? '#e2f0d9' : '#ffffff',
+                            borderRadius: '6px',
+                            borderLeft: '3px solid #4e73df',
+                            cursor: 'pointer',
+                            transition: 'all 0.2s',
+                            fontSize: '14px',
+                            fontWeight: '500',
+                            color: '#495057',
+                            boxShadow: '0 1px 3px rgba(0,0,0,0.1)',
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'space-between'
+                          }}
+                        >
+                          <span>{item.term}</span>
+                          {savedVocabularyItems.includes(item.term) && (
+                            <FontAwesomeIcon icon={faCheck} style={{ color: '#28a745', fontSize: '12px' }} />
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </>
+            )}
+
             <p className="question-text" style={{ lineHeight: '1.6', marginBottom: '8px' }}>{currentQuestion.text}</p>
             <ul className="options-list" style={{ listStyleType: 'none', paddingLeft: '0', margin: 0 }}>
               {currentQuestion.options.map((opt, idx) => {

--- a/src/styles/SmartQuiz.css
+++ b/src/styles/SmartQuiz.css
@@ -59,6 +59,12 @@
   background-color: #138496;
 }
 
+@media (max-width: 768px) {
+  .assistant-toggle-mobile {
+    display: none;
+  }
+}
+
 /* Desktop Styles */
 @media (min-width: 992px) {
   .assistant-panel {
@@ -499,4 +505,54 @@
 @keyframes fadeIn {
   from { opacity: 0; }
   to { opacity: 1; }
+}
+
+/* Mobile AI bar and vocabulary panel */
+.mobile-ai-bar {
+  display: none;
+}
+
+.ai-bar-button {
+  border: none;
+  background-color: #e9ecef;
+  padding: 8px 10px;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.9rem;
+}
+
+.mobile-vocabulary-panel {
+  display: none;
+}
+
+@media (max-width: 768px) {
+  .vocabulary-column,
+  .ai-tools-column {
+    display: none;
+  }
+
+  .mobile-ai-bar {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 12px;
+  }
+
+  .mobile-ai-bar .ai-bar-button {
+    flex: 1;
+  }
+
+  .mobile-vocabulary-panel {
+    background-color: #f8f9fa;
+    border-radius: 8px;
+    padding: 12px;
+    margin-bottom: 12px;
+    max-height: 240px;
+    overflow-y: auto;
+  }
+
+  .mobile-vocabulary-panel.open {
+    display: block;
+  }
 }


### PR DESCRIPTION
## Summary
- show AI helper controls in a compact mobile bar
- hide old toggle button and collapse vocabulary column on small screens
- allow terms to expand when a button is tapped

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859c0257124832581b4c265f5a68773