### PR TITLE
Improve mobile layout for SmartQuiz

### DIFF
--- a/src/pages/SmartQuiz.jsx
+++ b/src/pages/SmartQuiz.jsx
@@ -58,6 +58,7 @@ export default function SmartQuiz() {
   const [selectedVocabularyItem, setSelectedVocabularyItem] = useState(null);
   const [savingVocabularyItem, setSavingVocabularyItem] = useState(false);
   const [savedVocabularyItems, setSavedVocabularyItems] = useState([]);
+  const [showMobileVocab, setShowMobileVocab] = useState(false);
   
   // Load quiz document
   useEffect(() => {
@@ -619,6 +620,54 @@ export default function SmartQuiz() {
           </div>
         </div>
       </div>
+
+      {aiEnabled && (
+        <>
+          <div className="mobile-ai-bar">
+            <button onClick={() => setIsAssistantModalOpen(true)}>
+              <FontAwesomeIcon icon={faComment} />
+              <span>AI</span>
+            </button>
+            <button onClick={handleDirectTipRequest} disabled={assistantLoading}>
+              <FontAwesomeIcon icon={faLightbulb} />
+              <span>Tip</span>
+            </button>
+            <button onClick={handleDirectSummariseText} disabled={assistantLoading}>
+              <FontAwesomeIcon icon={faFileAlt} />
+              <span>Summary</span>
+            </button>
+            <button onClick={() => setShowMobileVocab(!showMobileVocab)}>
+              <FontAwesomeIcon icon={faBook} />
+              <span>Words</span>
+            </button>
+          </div>
+          {showMobileVocab && (
+            <div className="mobile-vocab-dropdown">
+              {helperLoading ? (
+                <p>Loading vocabulary...</p>
+              ) : helperItems.length === 0 ? (
+                <p>No vocabulary terms found.</p>
+              ) : (
+                <div className="vocabulary-items" style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+                  {helperItems.map((item, index) => (
+                    <div
+                      key={index}
+                      className="vocabulary-item"
+                      onClick={() => handleVocabularyItemClick(item)}
+                    >
+                      <span>{item.term}</span>
+                      {savedVocabularyItems.includes(item.term) && (
+                        <FontAwesomeIcon icon={faCheck} style={{ color: '#28a745', fontSize: '12px' }} />
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+        </>
+      )}
+
       {/* Modal for displaying tip or summary */}
       <Modal 
         isOpen={isModalOpen} 

--- a/src/styles/SmartQuiz.css
+++ b/src/styles/SmartQuiz.css
@@ -59,6 +59,35 @@
   background-color: #138496;
 }
 
+/* Mobile AI utilities */
+.mobile-ai-bar {
+  display: flex;
+  justify-content: space-around;
+  gap: 6px;
+  margin-bottom: 15px;
+}
+
+.mobile-ai-bar button {
+  flex: 1;
+  padding: 8px 6px;
+  border: none;
+  border-radius: 6px;
+  background-color: #f0f4f8;
+  font-size: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+.mobile-vocab-dropdown {
+  background-color: #f8f9fa;
+  padding: 15px;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  margin-bottom: 15px;
+}
+
 /* Desktop Styles */
 @media (min-width: 992px) {
   .assistant-panel {
@@ -70,6 +99,20 @@
   }
   
   .assistant-toggle-mobile {
+    display: none;
+  }
+}
+
+@media (max-width: 768px) {
+  .vocabulary-column,
+  .ai-tools-column {
+    display: none;
+  }
+}
+
+@media (min-width: 769px) {
+  .mobile-ai-bar,
+  .mobile-vocab-dropdown {
     display: none;
   }
 }
@@ -407,6 +450,27 @@
   flex-direction: column;
   gap: 8px; /* Consistent gap for buttons inside container */
   /* animation properties are applied inline in the JSX for dynamic conditional rendering */
+}
+
+.vocabulary-item {
+  padding: 8px 12px;
+  background-color: #ffffff;
+  border-left: 3px solid #4e73df;
+  border-radius: 6px;
+  font-size: 14px;
+  font-weight: 500;
+  color: #495057;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+  transition: background-color 0.2s, transform 0.2s;
+}
+
+.vocabulary-item:hover {
+  background-color: #e9ecef;
+  transform: translateX(2px);
 }
 
 /* Ensure other styles are not overriding */


### PR DESCRIPTION
## Summary
- add mobile-friendly UI for SmartQuiz
- hide left/right columns on small screens and show new top bar
- make vocabulary items reusable styles

## Testing
- `npm install`
- `npm test --silent -- -w=0`

------
https://chatgpt.com/codex/tasks/task_e_6859c0257124832581b4c265f5a68773