### PR TITLE
Fix duplicate AI buttons on mobile

### DIFF
--- a/src/pages/SmartQuiz.jsx
+++ b/src/pages/SmartQuiz.jsx
@@ -864,14 +864,16 @@ export default function SmartQuiz() {
 
         {/* Right Column: AI Buttons */}
         {aiEnabled && (
-          <div className="ai-tools-column" style={{
-            width: '150px',
-            flexShrink: 0,
-            display: 'flex',
-            flexDirection: 'column',
-            gap: '12px',
-            marginTop: '60px' // Align with question content
-          }}>
+          <div
+            className="ai-tools-column"
+            style={{
+              width: '150px',
+              flexShrink: 0,
+              flexDirection: 'column',
+              gap: '12px',
+              marginTop: '60px' // Align with question content
+            }}
+          >
             <button 
               className="assistant-action-button assistant-button"
               onClick={() => setIsAssistantModalOpen(true)}

--- a/src/styles/SmartQuiz.css
+++ b/src/styles/SmartQuiz.css
@@ -480,11 +480,12 @@
 
 /* AI Tools Column styling (if not already fully inline or elsewhere) */
 .ai-tools-column {
-  /* width: 150px; */
-  /* display: flex; */
-  /* flex-direction: column; */
-  /* gap: 12px; */
-  /* margin-top: 60px; */
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 60px;
+  width: 150px;
+  flex-shrink: 0;
 }
 
 .assistant-action-button {


### PR DESCRIPTION
## Summary
- remove inline display style from right sidebar button column
- style `.ai-tools-column` in CSS so it hides properly on small screens

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685ae107c37483258e8e364f1df9c27b