### PR TITLE
Improve SmartQuiz results layout

### DIFF
--- a/src/pages/SmartQuizResults.jsx
+++ b/src/pages/SmartQuizResults.jsx
@@ -219,24 +219,23 @@ export default function SmartQuizResults() {
                     <h3>{question.text}</h3>
                   </div>
                   
-                  <div className="answer-summary">
-                    <div className="answer-row">
-                      <span className="answer-label">Your answer:</span>
-                      <span className={`answer-value ${isCorrect ? 'correct-answer' : 'incorrect-answer'}`}>
-                        {question.options[answer.selectedOption]}
-                      </span>
-                    </div>
-                    {!isCorrect && (
-                      <div className="answer-row">
-                        <span className="answer-label">Correct answer:</span>
-                        <span className="answer-value correct-answer">
-                          {question.options[question.correctAnswer]}
-                        </span>
-                      </div>
-                    )}
-                    <div className="answer-meta">
-                      <span className="time-spent">⏱️ {answer.timeSpent}s</span>
-                    </div>
+                  <div className="options-list">
+                    {question.options.map((opt, idx) => {
+                      const isSelected = answer?.selectedOption === idx;
+                      const isCorrectOption = idx === question.correctAnswer;
+                      return (
+                        <div
+                          key={idx}
+                          className={`option-item ${isCorrectOption ? 'correct' : ''} ${isSelected ? 'selected' : ''}`}
+                        >
+                          <span className="option-letter">{String.fromCharCode(65 + idx)}.</span>
+                          <span className="option-text">{opt}</span>
+                        </div>
+                      );
+                    })}
+                  </div>
+                  <div className="answer-meta">
+                    <span className="time-spent">⏱️ {answer.timeSpent}s</span>
                   </div>
                 </div>
 

--- a/src/styles/SmartQuizResults.css
+++ b/src/styles/SmartQuizResults.css
@@ -341,6 +341,47 @@
   margin: 0;
 }
 
+.options-list {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 24px 0;
+}
+
+.option-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px;
+  margin-bottom: 8px;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  background: #fff;
+}
+
+.option-item.correct {
+  background: #f0fff4;
+  border-color: #9ae6b4;
+}
+
+.option-item.selected {
+  background: #fff5f5;
+  border-color: #fc8181;
+}
+
+.option-item.correct.selected {
+  background: #f0fff4;
+  border-color: #9ae6b4;
+}
+
+.option-letter {
+  font-weight: 700;
+  width: 20px;
+}
+
+.option-text {
+  flex: 1;
+}
+
 .answer-summary {
   background: linear-gradient(135deg, #f7fafc 0%, #edf2f7 100%);
   border-radius: 12px;


### PR DESCRIPTION
## Summary
- show question options in SmartQuiz results
- style options list for clarity

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685ae9961754832589e6dcdd648b3bd0